### PR TITLE
Updates vae

### DIFF
--- a/config/config_default.json
+++ b/config/config_default.json
@@ -10,13 +10,13 @@
     "data": {
         "dataset_name": "",
         "dataset_description": "fulldata",
-        "train_dataset": "train_data_pxpypz_g_min30p.pt",
-        "valid_dataset": "valid_data_pxpypz_g_min30p.pt",
-        "test_dataset": "test_data_pxpypz_g_min30p.pt",
+        "train_dataset": "train_data_pxpypz_g_150p.pt",
+        "valid_dataset": "valid_data_pxpypz_g_150p.pt",
+        "test_dataset": "test_data_pxpypz_g_150p.pt",
         "filename": "./dataset/phi025-025_eta025-025_train1_lasthit_20200219.csv",
         "train_split": 0.80,
         "normalize": true,
-	"data_percentage": 1.0
+	"data_percentage": 0.05
     },
     "physics": {
         "num_particles": 30,
@@ -41,7 +41,8 @@
         "num_features": 3,
         "latent_dim": 30,
         "vae_mode" : "generation",
-
+        "turn_pt_on_epoch" : 100,
+        "turn_pt_on_bool" : true,
 
 
         "validation": 0.3,

--- a/core/models/vae.py
+++ b/core/models/vae.py
@@ -26,7 +26,7 @@ plt.style.use(mhep.style.CMS)
 
 torch.autograd.set_detect_anomaly(True)
 
-device = torch.device("cuda:1" if torch.cuda.is_available() else "cpu")
+device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
 turnPtOnEpoch = configs['training']['turn_pt_on_epoch']
 turnPtOnBool = configs['training']['turn_pt_on_bool']
@@ -92,12 +92,13 @@ class ConvNet(nn.Module):
         self.conv1 = nn.Conv2d(1, 1 * self.n_filter, kernel_size=(self.num_features,5), stride=(1), padding=(0))
         self.conv2 = nn.Conv2d(1 * self.n_filter, 2 * self.n_filter, kernel_size=(1,5), stride=(1), padding=(0))
         self.conv3 = nn.Conv2d(2 * self.n_filter, 4 * self.n_filter, kernel_size=(1,5), stride=(1), padding=(0))
-        #
+
         self.fc1 = nn.Linear(1 * int(self.num_particles - 12) * 4 * self.n_filter, 1500)
         self.fc2 = nn.Linear(1500, 2 * self.latent_dim)
         #
         self.fc3 = nn.Linear(self.latent_dim, 1500)
         self.fc4 = nn.Linear(1500, 1 * int(self.num_particles - 12) * 4*self.n_filter)
+        
         self.conv4 = nn.ConvTranspose2d(4 * self.n_filter, 2 * self.n_filter, kernel_size=(1,5), stride=(1), padding=(0))
         self.conv5 = nn.ConvTranspose2d(2 * self.n_filter, 1 * self.n_filter, kernel_size=(1,5), stride=(1), padding=(0))
         self.conv6 = nn.ConvTranspose2d(1 * self.n_filter, 1, kernel_size=(self.num_features,5), stride=(1), padding=(0))

--- a/min30p_test_vae_nnd_training_evaluation_generation.py
+++ b/min30p_test_vae_nnd_training_evaluation_generation.py
@@ -32,7 +32,7 @@ from core.utils.utils import *
 from core.models.vae import *
 from core.data.data import *
 
-device = torch.device("cuda:1" if torch.cuda.is_available() else "cpu")
+device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
 def parse_args():
     """Parse arguments."""
@@ -125,6 +125,7 @@ def main():
         # Initialize model and load it on GPU
         model = ConvNet(configs, dataT.tr_max, dataT.tr_min)
         model = model.to(device)
+        print(model)
 
         # Optimizer
         optimizer = torch.optim.Adam(model.parameters(), lr=learning_rate)
@@ -426,29 +427,22 @@ def main():
                 minp = np.histogram(jets_input_data[:,0], bins=100, range = [0, 400])[0]
                 mout = np.histogram(jets_output_data[:,0], bins=100, range=[0, 400])[0]
                 mgen = np.histogram(jets_gen_output_data[:,0], bins=100, range = [0, 400])[0]
-                #plt.clf()
-
-                print(minp.shape,mout.shape)
 
                 ptinp = np.histogram(jets_input_data[:,1], bins=100, range=[0, 3000])[0]
                 ptout = np.histogram(jets_output_data[:,1], bins=100, range=[0, 3000])[0]
                 ptgen = np.histogram(jets_gen_output_data[:,1], bins=100, range=[0, 3000])[0]
-                #plt.clf()
 
                 einp = np.histogram(jets_input_data[:,2], bins=100, range = [200,4000])[0]
                 eout = np.histogram(jets_output_data[:,2], bins=100, range = [200,4000])[0]
                 egen = np.histogram(jets_gen_output_data[:,2], bins=100, range = [200,4000])[0]
-                #plt.clf()
 
                 etainp = np.histogram(jets_input_data[:,3], bins=100, range = [-3,3])[0]
                 etaout = np.histogram(jets_output_data[:,3], bins=100, range = [-3,3])[0]
                 etagen = np.histogram(jets_gen_output_data[:,3], bins=100, range = [-3,3])[0]
-                #plt.clf()
 
                 phiinp = np.histogram(jets_input_data[:,4], bins=100, range=[-3,3])[0]
                 phiout = np.histogram(jets_output_data[:,4], bins=100, range=[-3,3])[0]
                 phigen = np.histogram(jets_gen_output_data[:,4], bins=100, range=[-3,3])[0]
-                #plt.clf()
 
                 minp = (minp/minp.sum()) + 0.000000000001
                 ptinp = (ptinp/ptinp.sum()) + 0.000000000001

--- a/min30p_test_vae_nnd_training_evaluation_generation.py
+++ b/min30p_test_vae_nnd_training_evaluation_generation.py
@@ -125,7 +125,6 @@ def main():
         # Initialize model and load it on GPU
         model = ConvNet(configs, dataT.tr_max, dataT.tr_min)
         model = model.to(device)
-        print(model)
 
         # Optimizer
         optimizer = torch.optim.Adam(model.parameters(), lr=learning_rate)


### PR DESCRIPTION
Introduced following modifications:
- Changed the way particles are being plotted in main code; much faster now, and per epoch result can be printed at each epoch instead of at every saving_epoch
- gamma_1 and gamma_2 are now being calculated using jets mass and pT information
- Main network has reconstruction and generation modes (added flag in config.json); at reconstruction mode, it is possible to select the option to train with or without jet pT term in first turn_pt_on_epoch epochs